### PR TITLE
AccountMapでエラーになる不具合を修正

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -120,7 +120,7 @@ Resources:
                                 ].{
                                     Keys[1]: $string($round($number(Metrics.AmortizedCost.Amount) * 100) / 100) & " " & Metrics.AmortizedCost.Unit
                                 })
-                            }
+                            }[]
                         ) : []
                     ) %}
             Next: Parallel


### PR DESCRIPTION
AccountMapの処理で以下のエラーが発生していました

<img width="511" alt="image" src="https://github.com/user-attachments/assets/4a10ebfb-c296-43f1-9efd-d3b46cbe0e55">

```json
{
  "cause": "An error occurred while executing the state 'AccountMap' (entered at the event id #22). The JSONata expression '$states.input.accounts' specified for the field 'Items' returned an unexpected result type. Expected 'array', but was 'object' for value: {\"accountId\":\"<AWSアカウントID>\",\"description\":\"<概要>\",...略",
  "error": "States.QueryEvaluationError",
  "location": "Items",
  "state": "AccountMap"
}
```

配列を期待しているところにObjectが渡されてたみたいです